### PR TITLE
 Confirmation Page update

### DIFF
--- a/services/payload/src/components/batch/BatchPreviewSubmit.tsx
+++ b/services/payload/src/components/batch/BatchPreviewSubmit.tsx
@@ -1,12 +1,16 @@
 import React, { useState, useEffect } from 'react';
 import { useAllFormFields } from 'payload/components/forms';
-
+import BatchCredentialListPreview from '../List/BatchCredentialListPreview';
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '../ui/accordion';
 import { CredentialTemplate } from 'payload/generated-types';
+import { PaginatedDocs } from 'payload/dist/mongoose/types';
+import { useDocumentInfo } from 'payload/components/utilities';
 
 const BatchPreviewSubmit = React.forwardRef<HTMLElement>(function BatchPreviewSubmit(_props, ref) {
     const [template, setTemplate] = useState<CredentialTemplate | undefined>();
     const [fields] = useAllFormFields();
+    const [credData, setCredData ] = useState<PaginatedDocs<Credential>>();
+    const { id } = useDocumentInfo();
 
     useEffect(() => {
         if (fields.template.value) {
@@ -17,6 +21,24 @@ const BatchPreviewSubmit = React.forwardRef<HTMLElement>(function BatchPreviewSu
             setTemplate(undefined);
         }
     }, [fields?.template?.value]);
+
+
+    const fetchBatchCredentials = async (page = 1) => {
+        const res = await fetch('/api/get-batch-credentials', {
+            method: 'POST',
+            body: JSON.stringify({ batchId: id, page }),
+            headers: {
+                'Content-type': 'application/json; charset=UTF-8',
+            },
+        });
+        if (res.status === 200) {
+            const { data } = await res.json();
+
+            setCredData(data);
+            console.log('///get batch credentials', data);
+        }
+    };
+
 
     return (
         <section className="w-full h-full flex-shrink-0 p-10 overflow-y-auto" ref={ref}>
@@ -76,6 +98,16 @@ const BatchPreviewSubmit = React.forwardRef<HTMLElement>(function BatchPreviewSu
                     </AccordionContent>
                 </AccordionItem>
             </Accordion>
+
+            <section>
+                {id && credData && (
+                    <BatchCredentialListPreview
+                        data={credData}
+                        refetch={fetchBatchCredentials}
+                        readOnly={true}
+                    />
+                )}
+            </section>
         </section>
     );
 });

--- a/services/payload/src/components/batch/BatchPreviewSubmit.tsx
+++ b/services/payload/src/components/batch/BatchPreviewSubmit.tsx
@@ -9,8 +9,10 @@ import { useDocumentInfo } from 'payload/components/utilities';
 const BatchPreviewSubmit = React.forwardRef<HTMLElement>(function BatchPreviewSubmit(_props, ref) {
     const [template, setTemplate] = useState<CredentialTemplate | undefined>();
     const [fields] = useAllFormFields();
-    const [credData, setCredData ] = useState<PaginatedDocs<Credential>>();
+    const [credData, setCredData] = useState<PaginatedDocs<Credential>>();
     const { id } = useDocumentInfo();
+
+    console.log('///BATCH PREVIEW SUBMIT', 'batchid', id);
 
     useEffect(() => {
         if (fields.template.value) {
@@ -21,7 +23,6 @@ const BatchPreviewSubmit = React.forwardRef<HTMLElement>(function BatchPreviewSu
             setTemplate(undefined);
         }
     }, [fields?.template?.value]);
-
 
     const fetchBatchCredentials = async (page = 1) => {
         const res = await fetch('/api/get-batch-credentials', {
@@ -39,6 +40,9 @@ const BatchPreviewSubmit = React.forwardRef<HTMLElement>(function BatchPreviewSu
         }
     };
 
+    useEffect(() => {
+        fetchBatchCredentials();
+    }, [id]);
 
     return (
         <section className="w-full h-full flex-shrink-0 p-10 overflow-y-auto" ref={ref}>
@@ -49,7 +53,7 @@ const BatchPreviewSubmit = React.forwardRef<HTMLElement>(function BatchPreviewSu
                 Review and confirm the batch details before sending credentials to earners.
             </p>
 
-            <Accordion type="single" collapsible className="mb-5">
+            <Accordion type="single" className="mb-5" defaultValue="batch">
                 <AccordionItem value="batch">
                     <AccordionTrigger>Batch: {fields.title.value}</AccordionTrigger>
                     <AccordionContent>
@@ -74,7 +78,7 @@ const BatchPreviewSubmit = React.forwardRef<HTMLElement>(function BatchPreviewSu
                 </AccordionItem>
             </Accordion>
 
-            <Accordion type="single" collapsible className="mb-5">
+            <Accordion type="single" className="mb-5" defaultValue="template">
                 <AccordionItem value="template">
                     <AccordionTrigger>Template: {template?.title}</AccordionTrigger>
                     <AccordionContent>
@@ -99,15 +103,19 @@ const BatchPreviewSubmit = React.forwardRef<HTMLElement>(function BatchPreviewSu
                 </AccordionItem>
             </Accordion>
 
-            <section>
-                {id && credData && (
-                    <BatchCredentialListPreview
-                        data={credData}
-                        refetch={fetchBatchCredentials}
-                        readOnly={true}
-                    />
-                )}
-            </section>
+            <Accordion type="single" className="mb-5" defaultValue="credentials">
+                <AccordionItem value="credentials">
+                
+                    <AccordionTrigger>Credentials From CSV</AccordionTrigger>
+                    {id && credData && (
+                        <BatchCredentialListPreview
+                            data={credData}
+                            refetch={fetchBatchCredentials}
+                            readOnly={true}
+                        />
+                    )}
+                </AccordionItem>
+            </Accordion>
         </section>
     );
 });

--- a/services/payload/src/components/batch/BatchPreviewSubmit.tsx
+++ b/services/payload/src/components/batch/BatchPreviewSubmit.tsx
@@ -50,7 +50,7 @@ const BatchPreviewSubmit = React.forwardRef<HTMLElement>(function BatchPreviewSu
                 Confirmation
             </h2>
             <p className="text-[--theme-text] text-xl font-medium font-inter mb-15">
-                Review and confirm the batch details before sending credentials to earners.
+                Review and confirm the details for this batch before sending credential claim emails to earners. Please make sure the details for your batch are correct before submitting for processing.
             </p>
 
             <Accordion type="single" className="mb-5" defaultValue="batch">


### PR DESCRIPTION
See https://github.com/learningeconomy/admin-dashboard/issues/27
This updates the confirmation page such that:

- Accordians are open by default
- Add credential records list display 

<img width="1242" alt="Screenshot 2023-11-09 at 1 43 17 PM" src="https://github.com/learningeconomy/admin-dashboard/assets/18289875/55e33f41-eaf1-4812-b049-2b03e10367c5">
