### PR TITLE
Fix email templating insertion

### DIFF
--- a/services/payload/src/helpers/credential.helpers.ts
+++ b/services/payload/src/helpers/credential.helpers.ts
@@ -1,1 +1,6 @@
 export const AUTOMATIC_FIELDS = ['earnerName', 'credentialName', 'emailAddress', 'now'];
+
+export const objectWithoutKey = (object, key) => {
+    const { [key]: deletedKey, ...otherKeys } = object;
+    return { otherKeys, deletedKey };
+};


### PR DESCRIPTION
See https://github.com/learningeconomy/admin-dashboard/issues/31

This fixes the email not having template variable values being inserted that are part of the 'extraFields' field.

The structure of the object we pass into the handlebars function has nested fields like this:

{
name: 'Cred name',
extraFields: {
    subject: 'subject name',
    degreeType: 'Degree type'
}